### PR TITLE
Update Kira, Plotgitsch and Kicad-Diff

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,11 +228,11 @@ with lists to make tweaking pads for stencil creation easier. Functions include 
 
 ## Version Control Tools
 
-- ![](https://img.shields.io/badge/V5-%20KiCad-Green) [KiCad-Diff](https://github.com/Gasman2014/KiCad-Diff) - Python3 script for performing image diffs between pcbnew layout revisions in Git, SVN and Fossil VCS. Recent SVG based diff for significant speed improvements.
+- [KiCad-Diff](https://github.com/Gasman2014/KiCad-Diff) - Python3 script for performing image diffs between pcbnew layout revisions in Git, SVN and Fossil VCS. Recent SVG based diff for significant speed improvements.
 
 - [Massaging your git for kicad](https://jnavila.github.io/plotkicadsch/) - Instructions how to integrate KiCad with Git VCS
 
-- ![](https://img.shields.io/badge/V5-%20KiCad-Green) [PlotKicadsch](https://github.com/jnavila/plotkicadsch) - PlotKicadsch is a small tool to export Kicad Sch files to SVG pictures.
+- [PlotKicadsch](https://github.com/jnavila/plotkicadsch) - PlotKicadsch is a small tool to export Kicad Sch files to SVG pictures.
 
 - [Scripting KiCad Pcbnew exports](https://scottbezek.blogspot.si/2016/04/scripting-kicad-pcbnew-exports.html) - How to plot properly formated SVG files from pcbnew for VCS diff-ing
 
@@ -240,7 +240,7 @@ with lists to make tweaking pads for stencil creation easier. Functions include 
 
 - [KiCAD to SVG Converter](https://github.com/jmwright/oshw-code/tree/master/kicad_to_svg_converter) - Scripts for headless SVG generation of schematic files using eeschema.
 
-- ![](https://img.shields.io/badge/V5-%20KiCad-Green) [kiri](https://github.com/leoheck/kiri) - Kicad Revision Inspector (KiRI) that combines PlotKicadSch and KiCad-Diff into a single website, for Git repositories, having a visual and interactive revision system for schematics and layouts.
+- [kiri](https://github.com/leoheck/kiri) - Kicad Revision Inspector (KiRI) that combines PlotKicadSch and KiCad-Diff into a single website, for Git repositories, having a visual and interactive revision system for schematics and layouts.
 
 ## Half-Baked Tools
 

--- a/README.md
+++ b/README.md
@@ -228,11 +228,11 @@ with lists to make tweaking pads for stencil creation easier. Functions include 
 
 ## Version Control Tools
 
-- ![](https://img.shields.io/badge/V5-%20KiCad-Red) [KiCad-Diff](https://github.com/Gasman2014/KiCad-Diff) - Python3 script for performing image diffs between pcbnew layout revisions in Git, SVN and Fossil VCS. Recent SVG based diff for significant speed improvements.
+- ![](https://img.shields.io/badge/V5-%20KiCad-Green) [KiCad-Diff](https://github.com/Gasman2014/KiCad-Diff) - Python3 script for performing image diffs between pcbnew layout revisions in Git, SVN and Fossil VCS. Recent SVG based diff for significant speed improvements.
 
 - [Massaging your git for kicad](https://jnavila.github.io/plotkicadsch/) - Instructions how to integrate KiCad with Git VCS
 
-- ![](https://img.shields.io/badge/V5-%20KiCad-Red) [PlotKicadsch](https://github.com/jnavila/plotkicadsch) - PlotKicadsch is a small tool to export Kicad Sch files to SVG pictures.
+- ![](https://img.shields.io/badge/V5-%20KiCad-Green) [PlotKicadsch](https://github.com/jnavila/plotkicadsch) - PlotKicadsch is a small tool to export Kicad Sch files to SVG pictures.
 
 - [Scripting KiCad Pcbnew exports](https://scottbezek.blogspot.si/2016/04/scripting-kicad-pcbnew-exports.html) - How to plot properly formated SVG files from pcbnew for VCS diff-ing
 
@@ -240,7 +240,7 @@ with lists to make tweaking pads for stencil creation easier. Functions include 
 
 - [KiCAD to SVG Converter](https://github.com/jmwright/oshw-code/tree/master/kicad_to_svg_converter) - Scripts for headless SVG generation of schematic files using eeschema.
 
-- ![](https://img.shields.io/badge/V5-%20KiCad-Red) [kiri](https://github.com/leoheck/kiri) - Kicad Revision Inspector (KiRI) that combines PlotKicadSch and KiCad-Diff into a single website, for Git repositories, having a visual and interactive revision system for schematics and layouts.
+- ![](https://img.shields.io/badge/V5-%20KiCad-Green) [kiri](https://github.com/leoheck/kiri) - Kicad Revision Inspector (KiRI) that combines PlotKicadSch and KiCad-Diff into a single website, for Git repositories, having a visual and interactive revision system for schematics and layouts.
 
 ## Half-Baked Tools
 

--- a/README.md
+++ b/README.md
@@ -228,11 +228,11 @@ with lists to make tweaking pads for stencil creation easier. Functions include 
 
 ## Version Control Tools
 
-- [KiCad-Diff](https://github.com/Gasman2014/KiCad-Diff) - Python3 script for performing image diffs between pcbnew layout revisions in Git, SVN and Fossil VCS. Recent SVG based diff for significant speed improvements.
+- ![](https://img.shields.io/badge/V5-%20KiCad-Red) [KiCad-Diff](https://github.com/Gasman2014/KiCad-Diff) - Python3 script for performing image diffs between pcbnew layout revisions in Git, SVN and Fossil VCS. Recent SVG based diff for significant speed improvements.
 
 - [Massaging your git for kicad](https://jnavila.github.io/plotkicadsch/) - Instructions how to integrate KiCad with Git VCS
 
-- [PlotKicadsch](https://github.com/jnavila/plotkicadsch) - PlotKicadsch is a small tool to export Kicad Sch files to SVG pictures.
+- ![](https://img.shields.io/badge/V5-%20KiCad-Red) [PlotKicadsch](https://github.com/jnavila/plotkicadsch) - PlotKicadsch is a small tool to export Kicad Sch files to SVG pictures.
 
 - [Scripting KiCad Pcbnew exports](https://scottbezek.blogspot.si/2016/04/scripting-kicad-pcbnew-exports.html) - How to plot properly formated SVG files from pcbnew for VCS diff-ing
 
@@ -240,7 +240,7 @@ with lists to make tweaking pads for stencil creation easier. Functions include 
 
 - [KiCAD to SVG Converter](https://github.com/jmwright/oshw-code/tree/master/kicad_to_svg_converter) - Scripts for headless SVG generation of schematic files using eeschema.
 
-- [kdiff](https://github.com/leoheck/kdiff) - Kicad revision inspector that combines PlotKicadSch and KiCad-Diff into a single website, for Git repositories, to have a visual and interactive revision system for schematics and layouts.
+- ![](https://img.shields.io/badge/V5-%20KiCad-Red) [kiri](https://github.com/leoheck/kiri) - Kicad Revision Inspector (KiRI) that combines PlotKicadSch and KiCad-Diff into a single website, for Git repositories, having a visual and interactive revision system for schematics and layouts.
 
 ## Half-Baked Tools
 


### PR DESCRIPTION
Hi, I came here to change the `kdiff` repo that is `kira` now.
 
Then I saw these new badges for Kicad 6 and they are awesome.
Then, decided to use a badge to indicate that these repos only work with Kicad 5 for now.

- `plotgitsch` depends on .sch files
- `kicad-diff` dependeds on a fully defined python API (it kinds of works on 6, but it still has some issues to be solved when the API is ready)
- `kira` uses both `plotgitsch` and `kicad-diff` internally

Do you think this is fine?