### PR TITLE
Added Kicad6 badge to Ki-nTree

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ A utility to examine library components and move them between libraries.
 
 - [KiCad CSV Symbol Libraries](https://github.com/eeintech/kicad-database-utils-csv) - (:warning: Support limited to KiCad V5 and older versions) Manage KiCad symbol library files using CSV format. The purpose of this tool is to translate back and forth symbol library data (stored in “.lib” and “.dcm” files) into the CSV format.
 
-- [Ki-nTree](https://github.com/sparkmicro/Ki-nTree) - Fast and automated part creation tool for KiCad and InvenTree. From a manufacturer or Digi-Key part number, Ki-nTree uses Digi-Key's API to fetch the part specifications and automatically generates a KiCad symbol and/or InvenTree part.
+- ![](https://img.shields.io/badge/V6-%20KiCad-blue) [Ki-nTree](https://github.com/sparkmicro/Ki-nTree) - Fast and automated part creation tool for KiCad and InvenTree. From a manufacturer or Digi-Key part number, Ki-nTree uses Digi-Key's API to fetch the part specifications and automatically generates a KiCad symbol and/or InvenTree part.
 
 - [easyeda2kicad.py](https://github.com/uPesy/easyeda2kicad.py) - Convert any LCSC components (including EasyEDA components) to a KiCad library (symbol and footprint)
 


### PR DESCRIPTION
From https://github.com/sparkmicro/Ki-nTree
> Because of limited maintenance bandwidth, Ki-nTree versions 0.5.x and newer will only support KiCad version 6 ...